### PR TITLE
fix: disables errors while populating breadcrumbs

### DIFF
--- a/src/utilities/getParents.ts
+++ b/src/utilities/getParents.ts
@@ -19,6 +19,7 @@ const getParents = async (
         id: parent,
         collection: collection.slug,
         depth: 0,
+        disableErrors: true,
       });
     }
 


### PR DESCRIPTION
This PR ensures that if a page had a parent that is has been deleted, we do not throw an error upon attempting to populate it as a breadcrumb.